### PR TITLE
Enables widget control using a given key.

### DIFF
--- a/lib/src/show_up.dart
+++ b/lib/src/show_up.dart
@@ -38,7 +38,8 @@ class ShowUpAnimation extends StatefulWidget {
     this.direction = Direction.vertical,
     this.delayStart = const Duration(seconds: 0),
     this.animationDuration = const Duration(milliseconds: 800),
-  });
+    Key key,
+  }) : super(key: key);
 
   @override
   _ShowUpAnimationState createState() => _ShowUpAnimationState();


### PR DESCRIPTION
In a project in which I use the library, I came across the need to pass a UniqueKey() to the widget, in order to force the rebuild and therefore the animation.
I am happy to be contributing to a lib that I use and love